### PR TITLE
RAML 1.0 | Update to raml2html@6.3.0 on alpine:3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-RUN set -ex \
-  && apk update \
-  && apk upgrade \
-  && apk add --no-cache --update \
-    nodejs=6.9.2-r1 \
-  && npm i -g raml2html@5.0.0 \
-  && npm cache clean \
-  && rm -rf /var/cache/apk/*
+RUN apk add --no-cache --update nodejs-npm && \
+    npm install -g raml2html@6.3.0 && \
+    npm cache clean && \
+    rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["raml2html"]
 


### PR DESCRIPTION
Support for RAML 1.0

Update to raml2html@6.3.0 on alpine:3.6